### PR TITLE
Make beforeInsert & beforeRemove events cancelable

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ document.addEventListener('DOMContentLoaded', function () {
     newContents.forEach(function (node, i) {
       var contentNode = node;
 
-      var beforeInsert = new CustomEvent('cocoon:before-insert', { detail: [contentNode, originalEvent] });
+      var beforeInsert = new CustomEvent('cocoon:before-insert', { cancelable: true, detail: [contentNode, originalEvent] });
       insertionNodeElem.dispatchEvent(beforeInsert);
 
       if (!beforeInsert.defaultPrevented) {

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', function () {
     e.preventDefault();
     e.stopPropagation();
 
-    var beforeRemove = new CustomEvent('cocoon:before-remove', { detail: [nodeToDelete, originalEvent] });
+    var beforeRemove = new CustomEvent('cocoon:before-remove', { cancelable: true, detail: [nodeToDelete, originalEvent] });
     triggerNode.dispatchEvent(beforeRemove);
 
     if (!beforeRemove.defaultPrevented) {


### PR DESCRIPTION
Currently it's not possible to preventDefault on the beforeInsert and beforeRemove events because they are not cancelable - https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events#triggering_built-in_events

cc @dabroz 